### PR TITLE
Add simple build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 local/
 metadata/local.meta
 
-
+# Build stuff
+build/
+dist/
+.latest_release

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ This project is hosted on GitHub, https://github.com/hire-vladimir/SA-cim_vladia
 # Install
 App installation is simple, and only needs to be present on the search head. Documentation around app installation can be found at http://docs.splunk.com/Documentation/AddOns/released/Overview/Singleserverinstall
 
+You can also build a local package like so:
+
+    # Download from git
+    git clone https://github.com/hire-vladimir/SA-cim_vladiator
+    cd SA-cim_vladiator
+
+    # Launch the build process
+    ./build.sh
+
+    # Install into a local Splunk instance
+    $SPLUNK_HOME/bin/splunk install app $(<.latest_release)
+
 # Getting Started
 to fill
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+APP="SA-cim_vladiator"
+BUILD="build/$APP"
+VER=$(grep version default/app.conf | cut -f2 -d=)
+VER=${VER/ /}
+TARBALL=${APP}-${VER}.tgz
+echo "Building $APP ${VER}"
+echo
+
+# Clean existing build directory
+[[ -d "$BUILD" ]] || rm -rf "$BUILD"
+mkdir -p "$BUILD"
+
+echo "Creating build into $BUILD"
+cp -a ./*.md LICENSE bin appserver static default lookups metadata "$BUILD"
+find "$BUILD" -name '*.py[co]' -delete
+find "$BUILD" -name '.DS_Store' -delete
+
+echo "Exporting to $TARBALL"
+[[ -d "dist" ]] || mkdir dist
+
+
+# MAC OSX undocumented hack to prevent creation of '._*' folders
+export COPYFILE_DISABLE=1
+
+(
+cd build
+tar -czvf "../dist/$TARBALL" "$APP"
+)
+echo "dist/$TARBALL" > .latest_release
+
+echo
+echo "New release:  dist/$TARBALL"
+echo
+echo "You can copy this file to your Splunk server or install it locally by running:"
+echo
+echo "    \$SPLUNK_HOME/bin/splunk install app dist/$TARBALL"
+

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ echo "Building $APP ${VER}"
 echo
 
 # Clean existing build directory
-[[ -d "$BUILD" ]] || rm -rf "$BUILD"
+[[ -d "$BUILD" ]] && rm -rf "$BUILD"
 mkdir -p "$BUILD"
 
 echo "Creating build into $BUILD"


### PR DESCRIPTION
- Add build script that creates a new temporary folder and builds a .tgz file
  with the needed content and nothing else.  This avoids 2 common pitfalls:
  (1) Github tarball downloads end with an app name SA-cim_vladiator-master,
  and (2) it avoids hidden files (.gitignore); both are rejected by AppInspect.
- Add some simple command line steps for a typical git clone / build / splunk
  install app workflow
- Updated .gitignore to block build related artifacts.