### PR TITLE
Support for Python 3 & Splunk 8

### DIFF
--- a/bin/mvmath.py
+++ b/bin/mvmath.py
@@ -12,6 +12,14 @@ import time, os, re
 import logging, logging.handlers
 import splunk.Intersplunk as si
 
+# Mini 'six'-like compat layer
+import sys
+if sys.version_info[0] == 2:
+    string_types = (basestring,)
+else:
+    string_types = (str,)
+
+
 #######################################
 # SCRIPT CONFIG
 #######################################
@@ -50,7 +58,7 @@ def die(msg):
 
 
 def validate_args(keywords, argvals):
-    logger.info('function="validate_args" calling getKeywordsAndOptions keywords="%s" args="%s"' % (str(keywords), str(argvals)))
+    logger.info('function="validate_args" calling getKeywordsAndOptions keywords="%s" args="%s"', keywords, argvals)
 
     # validate keywords
     # if len(keywords) != 1:
@@ -102,9 +110,9 @@ if __name__ == '__main__':
             if argvals['field'] in row and argvals['field2'] in row:
                 tally = float(row[argvals['field2']])
                 vdata = row[argvals['field']]
-                res = [str(round(float(x) / tally * 100, 2)) + "%" for x in vdata]
-                if isinstance(vdata, str) and vdata is not "":
-                    res = str(round(float(vdata) / tally * 100, 2)) + "%"
+                res = ["{:.2%}".format(float(x) / tally) for x in vdata]
+                if isinstance(vdata, string_types) and vdata:
+                    res = "{:.2%}".format(float(vdata) / tally)
 
                 row[output_column_name + "_result"] = res
                 logger.debug('---> %s = vdata="%s", tally="%s", out="%s"' % (row['field'], vdata, tally, res))

--- a/bin/mvmath.py
+++ b/bin/mvmath.py
@@ -60,10 +60,10 @@ def validate_args(keywords, argvals):
     ALLOWED_OPTIONS = ['debug', 'field', 'field2', 'labelfield', 'prefix']
     MANDATORY_OPTIONS = []
 
-    if len(filter(lambda x: x in MANDATORY_OPTIONS, argvals)) < len(MANDATORY_OPTIONS):
+    if len([x for x in argvals if x in MANDATORY_OPTIONS]) < len(MANDATORY_OPTIONS):
         die("Insuffucient number of mandatory arguments found. Mandatory argumets are: %s" % MANDATORY_OPTIONS)
 
-    illegal_args = filter(lambda x: x not in ALLOWED_OPTIONS, argvals)
+    illegal_args = [x for x in argvals if x not in ALLOWED_OPTIONS]
     if len(illegal_args) != 0:
         die("The argument(s) '%s' is invalid. Supported arguments are: %s" % (illegal_args, ALLOWED_OPTIONS))
 
@@ -102,7 +102,7 @@ if __name__ == '__main__':
             if argvals['field'] in row and argvals['field2'] in row:
                 tally = float(row[argvals['field2']])
                 vdata = row[argvals['field']]
-                res = map(lambda x: str(round(float(x) / tally * 100, 2)) + "%", vdata)
+                res = [str(round(float(x) / tally * 100, 2)) + "%" for x in vdata]
                 if isinstance(vdata, str) and vdata is not "":
                     res = str(round(float(vdata) / tally * 100, 2)) + "%"
 
@@ -112,7 +112,7 @@ if __name__ == '__main__':
         # logger.debug('results="%s"' % results)
         logger.info('sending events to splunk count="%s"' % len(results))
         si.outputResults(results)
-    except Exception, e:
+    except Exception as e:
         logger.error('error while processing events, exception="%s"' % e)
         si.generateErrorResults(e)
         raise Exception(e)

--- a/bin/mvmath.py
+++ b/bin/mvmath.py
@@ -54,7 +54,7 @@ def setup_logging():  # setup logging
 
 def die(msg):
     logger.error(msg)
-    exit("mvmath: %s" % msg)
+    exit("mvmath: %s" % (msg,))
 
 
 def validate_args(keywords, argvals):
@@ -69,7 +69,7 @@ def validate_args(keywords, argvals):
     MANDATORY_OPTIONS = []
 
     if len([x for x in argvals if x in MANDATORY_OPTIONS]) < len(MANDATORY_OPTIONS):
-        die("Insuffucient number of mandatory arguments found. Mandatory argumets are: %s" % MANDATORY_OPTIONS)
+        die("Insuffucient number of mandatory arguments found. Mandatory argumets are: %s" % (MANDATORY_OPTIONS,))
 
     illegal_args = [x for x in argvals if x not in ALLOWED_OPTIONS]
     if len(illegal_args) != 0:
@@ -115,14 +115,14 @@ if __name__ == '__main__':
                     res = "{:.2%}".format(float(vdata) / tally)
 
                 row[output_column_name + "_result"] = res
-                logger.debug('---> %s = vdata="%s", tally="%s", out="%s"' % (row['field'], vdata, tally, res))
+                logger.debug('---> %s = vdata="%s", tally="%s", out="%s"', row['field'], vdata, tally, res)
 
         # logger.debug('results="%s"' % results)
-        logger.info('sending events to splunk count="%s"' % len(results))
+        logger.info('sending events to splunk count="%d"', len(results))
         si.outputResults(results)
     except Exception as e:
-        logger.error('error while processing events, exception="%s"' % e)
+        logger.exception('error while processing events, exception="%s"', e)
         si.generateErrorResults(e)
-        raise Exception(e)
+        raise
     finally:
-        logger.info('exiting, execution duration=%s seconds' % (time.time() - eStart))
+        logger.info('exiting, execution duration=%s seconds', time.time() - eStart)

--- a/bin/mvrex.py
+++ b/bin/mvrex.py
@@ -69,11 +69,13 @@ def validate_args(keywords, argvals):
 
 
 def get_count(d):
-    ret = 1  # this will take care of cases when no mv is involved
-    if (d is "") or (d == ['']) or (d == []):
-        ret = 0
-    elif isinstance(d, list):
+    # this will take care of cases when no mv is involved
+    if isinstance(d, list):
         ret = len(d)
+        if ret == 1 and not d[0]:
+            ret = 0
+    else:
+        ret = 1
     return ret
 
 

--- a/bin/mvrex.py
+++ b/bin/mvrex.py
@@ -50,7 +50,7 @@ def die(msg):
 
 
 def validate_args(keywords, argvals):
-    logger.info('function="validate_args" calling getKeywordsAndOptions keywords="%s" args="%s"' % (str(keywords), str(argvals)))
+    logger.info('function="validate_args" calling getKeywordsAndOptions keywords="%s" args="%s"', keywords, argvals)
 
     # validate keywords
     if len(keywords) != 1:

--- a/bin/mvrex.py
+++ b/bin/mvrex.py
@@ -60,10 +60,10 @@ def validate_args(keywords, argvals):
     ALLOWED_OPTIONS = ['debug', 'field', 'showunmatched', 'prefix', 'showcount', 'labelfield']
     MANDATORY_OPTIONS = ['field']
 
-    if len(filter(lambda x: x in MANDATORY_OPTIONS, argvals)) < len(MANDATORY_OPTIONS):
+    if len([x for x in argvals if x in MANDATORY_OPTIONS]) < len(MANDATORY_OPTIONS):
         die("Insuffucient number of mandatory arguments found. Mandatory argumets are: %s" % MANDATORY_OPTIONS)
 
-    illegal_args = filter(lambda x: x not in ALLOWED_OPTIONS, argvals)
+    illegal_args = [x for x in argvals if x not in ALLOWED_OPTIONS]
     if len(illegal_args) != 0:
         die("The argument(s) '%s' is invalid. Supported arguments are: %s" % (illegal_args, ALLOWED_OPTIONS))
 
@@ -123,10 +123,10 @@ if __name__ == '__main__':
             # perform match
             if isinstance(input_data, list):
                 logger.debug("dealing wiht mv field, will match per mv value")
-                row[output_column_name + "_matches"] = filter(lambda x: re.findall(regex, x), input_data)
+                row[output_column_name + "_matches"] = [x for x in input_data if re.findall(regex, x)]
 
                 if arg_on_and_enabled(argvals, "showunmatched", is_bool=True):
-                    row[output_column_name + "_unmatched"] = filter(lambda x: x not in row[output_column_name + "_matches"], input_data)
+                    row[output_column_name + "_unmatched"] = [x for x in input_data if x not in row[output_column_name + "_matches"]]
             else:
                 logger.debug("dealing with string, will match string")
                 row[output_column_name + "_matches"] = re.findall(regex, input_data)
@@ -144,7 +144,7 @@ if __name__ == '__main__':
         # logger.debug('results="%s"' % results)
         logger.info('sending events to splunk count="%s"' % len(results))
         si.outputResults(results)
-    except Exception, e:
+    except Exception as e:
         logger.error('error while processing events, exception="%s"' % e)
         si.generateErrorResults(e)
         raise Exception(e)

--- a/bin/mvrex.py
+++ b/bin/mvrex.py
@@ -46,7 +46,7 @@ def setup_logging():  # setup logging
 
 def die(msg):
     logger.error(msg)
-    exit("mvrex: %s" % msg)
+    exit("mvrex: %s" % (msg,))
 
 
 def validate_args(keywords, argvals):
@@ -61,7 +61,7 @@ def validate_args(keywords, argvals):
     MANDATORY_OPTIONS = ['field']
 
     if len([x for x in argvals if x in MANDATORY_OPTIONS]) < len(MANDATORY_OPTIONS):
-        die("Insuffucient number of mandatory arguments found. Mandatory argumets are: %s" % MANDATORY_OPTIONS)
+        die("Insuffucient number of mandatory arguments found. Mandatory argumets are: %s" % (MANDATORY_OPTIONS,))
 
     illegal_args = [x for x in argvals if x not in ALLOWED_OPTIONS]
     if len(illegal_args) != 0:
@@ -101,7 +101,7 @@ if __name__ == '__main__':
             logger.debug("detecting debug argument passed, setting command log_level=DEBUG")
 
         regex = keywords[0]
-        logger.debug('will be applying regex="%s", to field="%s"' % (regex, argvals['field']))
+        logger.debug('will be applying regex="%s", to field="%s"', regex, argvals['field'])
 
         output_column_name = "mvrex"
         if arg_on_and_enabled(argvals, "labelfield"):
@@ -114,7 +114,7 @@ if __name__ == '__main__':
             regex = keywords[0]
             if regex in row:
                 regex = row[regex]
-                logger.debug('found substitution oppty, will be applying regex="%s", to field="%s"' % (regex, argvals['field']))
+                logger.debug('found substitution oppty, will be applying regex="%s", to field="%s"', regex, argvals['field'])
 
             input_data = ""
             if argvals['field'] in row:
@@ -133,7 +133,7 @@ if __name__ == '__main__':
 
                 if arg_on_and_enabled(argvals, "showunmatched", is_bool=True) and get_count(row[output_column_name + "_matches"]) == 0:
                     row[output_column_name + "_unmatched"] = input_data
-            logger.debug('applying regex="%s" to dataset="%s", matches="%d"' % (regex, input_data, len(row[output_column_name + "_matches"])))
+            logger.debug('applying regex="%s" to dataset="%s", matches="%d"', regex, input_data, len(row[output_column_name + "_matches"]))
 
             if arg_on_and_enabled(argvals, "showcount", is_bool=True):
                 row[output_column_name + "_matched_count"] = get_count(row[output_column_name + "_matches"])
@@ -142,11 +142,11 @@ if __name__ == '__main__':
                     row[output_column_name + "_unmatched_count"] = int(row[output_column_name + "_input_count"]) - int(row[output_column_name + "_matched_count"])
 
         # logger.debug('results="%s"' % results)
-        logger.info('sending events to splunk count="%s"' % len(results))
+        logger.info('sending events to splunk count="%d"', len(results))
         si.outputResults(results)
     except Exception as e:
-        logger.error('error while processing events, exception="%s"' % e)
+        logger.exception('error while processing events, exception="%s"', e)
         si.generateErrorResults(e)
-        raise Exception(e)
+        raise
     finally:
-        logger.info('exiting, execution duration=%s seconds' % (time.time() - eStart))
+        logger.info('exiting, execution duration=%s seconds', time.time() - eStart)

--- a/default/commands.conf
+++ b/default/commands.conf
@@ -10,6 +10,7 @@ supports_multivalues = true
 enableheader = false
 stderr_dest = message
 local = false
+python.version = python3
 
 [mvmath]
 filename = mvmath.py
@@ -23,3 +24,4 @@ supports_multivalues = true
 enableheader = false
 stderr_dest = message
 local = false
+python.version = python3


### PR DESCRIPTION
Add Splunk 8 support (Python 3) for 2 custom SPL commands along with a few other (more opinionated) cleanups / enhancements.  I tried to keep all the bit in separate commits to make any of this easy to reverse out or cherry pick as you see fit.

This should close #20.