### PR TITLE
Add versioned .spl release pipeline with AppInspect cloud-tag gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Build and release .spl
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       version:
@@ -35,6 +37,9 @@ jobs:
             TAG="${{ github.event.release.tag_name }}"
             VERSION="${TAG#v}"
             APP_ID="SA-cim_vladiator"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
+            APP_ID="SA-cim_vladiator_pr${{ github.event.pull_request.number }}"
           else
             VERSION="${{ inputs.version }}"
             SAFE_BRANCH=$(printf '%s' "${{ github.ref_name }}" | tr -c 'A-Za-z0-9_' '_')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,20 +28,24 @@ jobs:
       - name: Install Splunk AppInspect
         run: pip install splunk-appinspect
 
-      - name: Derive version
+      - name: Derive version and app ID
         id: version
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             TAG="${{ github.event.release.tag_name }}"
             VERSION="${TAG#v}"
+            APP_ID="SA-cim_vladiator"
           else
             VERSION="${{ inputs.version }}"
+            SAFE_BRANCH=$(echo "${{ github.ref_name }}" | tr -c 'A-Za-z0-9_' '_')
+            APP_ID="SA-cim_vladiator_${SAFE_BRANCH}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
 
       - name: Stage app package
         run: |
-          mkdir -p build/SA-cim_vladiator
+          mkdir -p "build/${{ steps.version.outputs.app_id }}"
           # Copy everything except CI/repo-only files
           rsync -a \
             --exclude='.git' \
@@ -49,19 +53,19 @@ jobs:
             --exclude='.gitignore' \
             --exclude='build' \
             --exclude='*.spl' \
-            ./ build/SA-cim_vladiator/
+            ./ "build/${{ steps.version.outputs.app_id }}/"
 
-      - name: Inject version and build number
+      - name: Inject version, build number, and app ID
         run: |
-          sed -i "s/%%VERSION%%/${{ steps.version.outputs.version }}/" \
-            build/SA-cim_vladiator/default/app.conf
-          sed -i "s/%%BUILD%%/${{ github.run_number }}/" \
-            build/SA-cim_vladiator/default/app.conf
-          grep -E '^(version|build)' build/SA-cim_vladiator/default/app.conf
+          APP_CONF="build/${{ steps.version.outputs.app_id }}/default/app.conf"
+          sed -i "s/%%VERSION%%/${{ steps.version.outputs.version }}/" "$APP_CONF"
+          sed -i "s/%%BUILD%%/${{ github.run_number }}/" "$APP_CONF"
+          sed -i "s/%%APPID%%/${{ steps.version.outputs.app_id }}/" "$APP_CONF"
+          grep -E '^(id|label|version|build)' "$APP_CONF"
 
       - name: Run Splunk AppInspect
         run: |
-          splunk-appinspect inspect build/SA-cim_vladiator \
+          splunk-appinspect inspect "build/${{ steps.version.outputs.app_id }}" \
             --mode precert \
             --included-tags cloud \
             --output-file appinspect_report.json \
@@ -98,18 +102,18 @@ jobs:
       - name: Build .spl package
         run: |
           cd build
-          tar czf SA-cim_vladiator.spl SA-cim_vladiator
-          mv SA-cim_vladiator.spl ../
+          tar czf "${{ steps.version.outputs.app_id }}.spl" "${{ steps.version.outputs.app_id }}"
+          mv "${{ steps.version.outputs.app_id }}.spl" ../
 
       - name: Upload .spl as workflow artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: SA-cim_vladiator.spl
-          path: SA-cim_vladiator.spl
+          name: ${{ steps.version.outputs.app_id }}.spl
+          path: ${{ steps.version.outputs.app_id }}.spl
 
       - name: Attach .spl to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: SA-cim_vladiator.spl
+          files: ${{ steps.version.outputs.app_id }}.spl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,13 @@ jobs:
             --exclude='*.spl' \
             ./ build/SA-cim_vladiator/
 
-      - name: Inject version
+      - name: Inject version and build number
         run: |
           sed -i "s/%%VERSION%%/${{ steps.version.outputs.version }}/" \
             build/SA-cim_vladiator/default/app.conf
-          grep '^version' build/SA-cim_vladiator/default/app.conf
+          sed -i "s/%%BUILD%%/${{ github.run_number }}/" \
+            build/SA-cim_vladiator/default/app.conf
+          grep -E '^(version|build)' build/SA-cim_vladiator/default/app.conf
 
       - name: Run Splunk AppInspect
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           splunk-appinspect inspect build/SA-cim_vladiator \
             --mode precert \
+            --included-tags cloud \
             --output-file appinspect_report.json
 
           # Fail the build if AppInspect reports any "failure" results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
 permissions:
   contents: write
 
+env:
+  APP_BASE_NAME: SA-cim_vladiator
+
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -36,14 +39,14 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             TAG="${{ github.event.release.tag_name }}"
             VERSION="${TAG#v}"
-            APP_ID="SA-cim_vladiator"
+            APP_ID="${{ env.APP_BASE_NAME }}"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
-            APP_ID="SA-cim_vladiator_pr${{ github.event.pull_request.number }}"
+            APP_ID="${{ env.APP_BASE_NAME }}_pr${{ github.event.pull_request.number }}"
           else
             VERSION="${{ inputs.version }}"
             SAFE_BRANCH=$(printf '%s' "${{ github.ref_name }}" | tr -c 'A-Za-z0-9_' '_')
-            APP_ID="SA-cim_vladiator_${SAFE_BRANCH}"
+            APP_ID="${{ env.APP_BASE_NAME }}_${SAFE_BRANCH}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,22 @@ on:
         default: "0.0.0-manual"
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   APP_BASE_NAME: SA-cim_vladiator
 
 jobs:
-  package:
+  build:
     runs-on: ubuntu-latest
+    outputs:
+      app_id: ${{ steps.version.outputs.app_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -99,7 +101,7 @@ jobs:
 
       - name: Upload AppInspect report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: appinspect-report
           path: |
@@ -114,14 +116,24 @@ jobs:
           mv "${{ steps.version.outputs.app_id }}.spl" ../
 
       - name: Upload .spl as workflow artifact
-        if: github.event_name != 'release'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.version.outputs.app_id }}.spl
           path: ${{ steps.version.outputs.app_id }}.spl
 
-      - name: Attach .spl to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+  release:
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download .spl artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          files: ${{ steps.version.outputs.app_id }}.spl
+          name: ${{ needs.build.outputs.app_id }}.spl
+
+      - name: Attach .spl to release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          files: ${{ needs.build.outputs.app_id }}.spl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             APP_ID="SA-cim_vladiator"
           else
             VERSION="${{ inputs.version }}"
-            SAFE_BRANCH=$(echo "${{ github.ref_name }}" | tr -c 'A-Za-z0-9_' '_')
+            SAFE_BRANCH=$(printf '%s' "${{ github.ref_name }}" | tr -c 'A-Za-z0-9_' '_')
             APP_ID="SA-cim_vladiator_${SAFE_BRANCH}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           rsync -a \
             --exclude='.git' \
             --exclude='.github' \
+            --exclude='.gitignore' \
             --exclude='build' \
             --exclude='*.spl' \
             ./ build/SA-cim_vladiator/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,8 @@ jobs:
           splunk-appinspect inspect build/SA-cim_vladiator \
             --mode precert \
             --included-tags cloud \
-            --output-file appinspect_report.json
+            --output-file appinspect_report.json \
+            --generate-feedback
 
           # Fail the build if AppInspect reports any "failure" results
           python3 - <<'EOF'
@@ -89,7 +90,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: appinspect-report
-          path: appinspect_report.json
+          path: |
+            appinspect_report.json
+            inspect.yml
+          if-no-files-found: warn
 
       - name: Build .spl package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Build and release .spl
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to inject into app.conf (e.g. 0.0.1-test). Only used for manual runs."
+        required: false
+        default: "0.0.0-manual"
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Splunk AppInspect
+        run: pip install splunk-appinspect
+
+      - name: Derive version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Stage app package
+        run: |
+          mkdir -p build/SA-cim_vladiator
+          # Copy everything except CI/repo-only files
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='build' \
+            --exclude='*.spl' \
+            ./ build/SA-cim_vladiator/
+
+      - name: Inject version
+        run: |
+          sed -i "s/%%VERSION%%/${{ steps.version.outputs.version }}/" \
+            build/SA-cim_vladiator/default/app.conf
+          grep '^version' build/SA-cim_vladiator/default/app.conf
+
+      - name: Run Splunk AppInspect
+        run: |
+          splunk-appinspect inspect build/SA-cim_vladiator \
+            --mode precert \
+            --output-file appinspect_report.json
+
+          # Fail the build if AppInspect reports any "failure" results
+          python3 - <<'EOF'
+          import json, sys
+          report = json.load(open("appinspect_report.json"))
+          failures = []
+          for group in report.get("reports", []):
+              for check_group in group.get("groups", []):
+                  for check in check_group.get("checks", []):
+                      if check.get("result") == "failure":
+                          failures.append(f"{check_group.get('name')}: {check.get('name')}")
+          if failures:
+              print("AppInspect FAILURES:")
+              for f in failures:
+                  print(f" - {f}")
+              sys.exit(1)
+          print("AppInspect passed with no failures.")
+          EOF
+
+      - name: Upload AppInspect report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: appinspect-report
+          path: appinspect_report.json
+
+      - name: Build .spl package
+        run: |
+          cd build
+          tar czf SA-cim_vladiator.spl SA-cim_vladiator
+          mv SA-cim_vladiator.spl ../
+
+      - name: Upload .spl as workflow artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: SA-cim_vladiator.spl
+          path: SA-cim_vladiator.spl
+
+      - name: Attach .spl to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: SA-cim_vladiator.spl

--- a/default/app.conf
+++ b/default/app.conf
@@ -9,7 +9,7 @@ label = SA-cim_vladiator
 [launcher]
 author = hire.vladimir@gmail.com
 description = https://github.com/hire-vladimir/SA-cim_vladiator
-version = 2.0.0
+version = %%VERSION%%
 
 [package]
 id = SA-cim_vladiator

--- a/default/app.conf
+++ b/default/app.conf
@@ -1,6 +1,6 @@
 [install]
 is_configured = false
-build = 2.0.0
+build = %%BUILD%%
 
 [ui]
 is_visible = 1

--- a/default/app.conf
+++ b/default/app.conf
@@ -4,7 +4,7 @@ build = %%BUILD%%
 
 [ui]
 is_visible = 1
-label = SA-cim_vladiator
+label = %%APPID%%
 
 [launcher]
 author = hire.vladimir@gmail.com
@@ -12,4 +12,4 @@ description = https://github.com/hire-vladimir/SA-cim_vladiator
 version = %%VERSION%%
 
 [package]
-id = SA-cim_vladiator
+id = %%APPID%%


### PR DESCRIPTION
Adds a GitHub Actions workflow (`.github/workflows/release.yml`) that builds a Splunk `.spl` package and runs Splunk AppInspect (precert mode, cloud tag) as a gate.

- `app.conf` now uses `%%VERSION%%`, `%%BUILD%%`, `%%APPID%%` macros, injected at build time
- Version comes from the release tag; build number from the run number
- Manual `workflow_dispatch` and `pull_request` builds produce branch/PR-suffixed app IDs (e.g. `SA-cim_vladiator_dev`) so test packages can install side-by-side with the production app
- AppInspect failures block the build; report (JSON + feedback YAML on failure) uploaded as an artifact
- Split into `build` (read-only) and `release` (write, release-only) jobs; all third-party actions pinned to commit SHAs