### PR TITLE
ci: bump pinned actions to Node24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
       app_id: ${{ steps.version.outputs.app_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload AppInspect report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: appinspect-report
           path: |
@@ -116,7 +116,7 @@ jobs:
           mv "${{ steps.version.outputs.app_id }}.spl" ../
 
       - name: Upload .spl as workflow artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.version.outputs.app_id }}.spl
           path: ${{ steps.version.outputs.app_id }}.spl
@@ -129,11 +129,11 @@ jobs:
       contents: write
     steps:
       - name: Download .spl artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ needs.build.outputs.app_id }}.spl
 
       - name: Attach .spl to release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: ${{ needs.build.outputs.app_id }}.spl


### PR DESCRIPTION
- actions/checkout v4 -> v5
- actions/setup-python v5 -> v6
- actions/upload-artifact v4 -> v7 (both occurrences)
- actions/download-artifact v4 -> v8
- softprops/action-gh-release v2 -> v3

GitHub Actions is dropping the Node20 runtime (forced default 2026-06-16, removed 2026-09-16). All pins above were stuck on node20 and are replaced with the latest tags using node24, per each action's action.yml. Verified inputs used by this workflow (name, path, if-no-files-found, files, token) are unchanged across these version bumps.